### PR TITLE
Using transaction instead of db

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,8 +85,8 @@ func main() {
 	// in `crdbgorm.ExecuteTx`, a helper function for GORM which
 	// implements a retry loop
 	if err := crdbgorm.ExecuteTx(context.Background(), db, nil,
-		func(*gorm.DB) error {
-			return transferFunds(db, fromID, toID, amount)
+		func(tx *gorm.DB) error {
+			return transferFunds(tx, fromID, toID, amount)
 		},
 	); err != nil {
 		// For information and reference documentation, see:


### PR DESCRIPTION
Using DB, instead of the transaction, does not really maintain ACID properties of a transaction. I believe, it was an unintentional bug in the example.